### PR TITLE
Add method to add additional styles

### DIFF
--- a/lib/genki.js
+++ b/lib/genki.js
@@ -5,32 +5,42 @@ var barista = require('seed-barista');
 var jQuery = require('jquery');
 var jsdom = require('jsdom').jsdom;
 
-var Genki = function() {
-  this.window;
-  this.document;
-  this.jQuery;
-  this.$;
-  this.styles;
+var Genki = function(options) {
+  this.window = false;
+  this.document = false;
+  this.jQuery = false;
+  this.$ = false;
+  this.styles = [];
   this.options = {
     src: '/',
   };
+
+  this.generate(options);
+  return this;
 };
 
-Genki.prototype.generateStyles = function(options) {
+Genki.prototype.generate = function(options) {
+  this.window = jsdom('<html><head></head><body></body></html>').defaultView;
+  this.document = this.window.document;
+  this.$ = this.jQuery = jQuery(this.window);
+  this.addStyle(options);
+  return this;
+};
+
+Genki.prototype.addStyle = function(options) {
   this.options = assign(this.options, options);
-  this.styles = barista(this.options);
-  if (this.styles) {
-    this.$('head').append('<style>'+this.styles.css+'</style>');
+  var styles = barista(this.options);
+  if (styles) {
+    this.$('head').append('<style>'+styles.css+'</style>');
+    this.styles.push(styles);
   }
   return this;
 };
 
-Genki.prototype.start = function(options) {
-  this.window = jsdom('<html><head></head><body></body></html>').defaultView;
-  this.document = this.window.document;
-  this.$ = this.jQuery = jQuery(this.window);
-  this.generateStyles(options);
-  return this;
+var start = function(options) {
+  return new Genki(options);
 };
 
-module.exports = new Genki();
+module.exports = {
+  start: start,
+};

--- a/test/_genki.js
+++ b/test/_genki.js
@@ -1,3 +1,4 @@
+/* globals describe: true, it: true */
 'use strict';
 
 var expect = require('chai').expect;

--- a/test/genki.addStyle.js
+++ b/test/genki.addStyle.js
@@ -1,0 +1,37 @@
+/* globals describe: true, it: true */
+'use strict';
+
+var expect = require('chai').expect;
+var genki = require('../index');
+
+describe('genki.addStyle', function() {
+  var world = genki.start();
+  world.$('body').html(`
+    <div class="hosei">It's a science</div>
+  `);
+  var $el = world.$('.hosei');
+
+  it('should start with no styles', function() {
+    expect(world.styles.length).to.equal(0);
+  });
+
+  it('should add a single <style> with .addStyle()', function() {
+    world.addStyle({
+      content: `.hosei { background: blue }`,
+    });
+
+    expect(world.styles.length).to.equal(1);
+    expect(world.$('style').length).to.equal(1);
+    expect($el.css('background')).to.equal('blue');
+  });
+
+  it('should add additiontal <style> with .addStyle()', function() {
+    world.addStyle({
+      content: `.hosei { padding: 10px }`,
+    });
+
+    expect(world.styles.length).to.equal(2);
+    expect(world.$('style').length).to.equal(2);
+    expect($el.css('padding')).to.equal('10px');
+  });
+});

--- a/test/genki.css.js
+++ b/test/genki.css.js
@@ -1,3 +1,4 @@
+/* globals describe: true, it: true */
 'use strict';
 
 var expect = require('chai').expect;
@@ -35,7 +36,7 @@ describe('genki.css', function() {
     });
 
     expect(world.styles).to.exist;
-    expect(world.styles.data).to.exist;
-    expect(world.styles.data.nodes).to.exist;
+    expect(world.styles[0].data).to.exist;
+    expect(world.styles[0].data.nodes).to.exist;
   });
 });


### PR DESCRIPTION
* Refactor genki.js when required to have fresh JSDOM environments on start
* Refactor generateStyles() -> addStyle() to push new barista styles to a styles array
* Add tests for addStyle()

Example:
```js
var world = genki.start();

world.addStyle({
  content: `.hosei { background: blue }`
});

world.addStyle({
  content: `.hamada { background: red }`
});
```

Resolves: https://github.com/ItsJonQ/genki/issues/3