### PR TITLE
Disable CSSOM by default

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,22 @@
+{
+  "browser": true,
+  "jquery": true,
+  "node": true,
+  "esversion": 6,
+  "camelcase": true,
+  "eqeqeq": true,
+  "indent": 2,
+  "latedef": true,
+  "maxlen": 100,
+  "newcap": true,
+  "quotmark": "single",
+  "strict": true,
+  "undef": true,
+  "unused": true,
+  "eqnull": true,
+  "globals": {
+    "assert": true,
+    "describe": true,
+    "it": true
+  }
+}

--- a/lib/genki.js
+++ b/lib/genki.js
@@ -13,6 +13,7 @@ var Genki = function(options) {
   this.styles = [];
   this.options = {
     src: '/',
+    enableCSSOM: false,
   };
 
   this.generate(options);

--- a/lib/genki.js
+++ b/lib/genki.js
@@ -32,7 +32,10 @@ Genki.prototype.addStyle = function(options) {
   this.options = assign(this.options, options);
   var styles = barista(this.options);
   if (styles) {
-    this.$('head').append('<style>'+styles.css+'</style>');
+    var head = this.document.getElementsByTagName('head')[0];
+    var s = this.document.createElement('style');
+    s.innerHTML = styles.css;
+    head.appendChild(s);
     this.styles.push(styles);
   }
   return this;

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "CSS Unit Testing",
   "main": "index.js",
   "scripts": {
-    "lint": "jshint index.js test/",
+    "lint": "jshint index.js lib/ test/",
     "test": "npm run lint && mocha --recursive"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "CSS Unit Testing",
   "main": "index.js",
   "scripts": {
-    "test": "mocha"
+    "lint": "jshint index.js test/",
+    "test": "npm run lint && mocha --recursive"
   },
   "repository": {
     "type": "git",
@@ -14,12 +15,13 @@
   "license": "MIT",
   "devDependencies": {
     "chai": "3.5.0",
+    "jshint": "2.9.4",
     "mocha": "3.2.0"
   },
   "dependencies": {
     "jquery": "3.2.1",
     "jsdom": "9.12.0",
-    "lodash.assign": "^4.2.0",
-    "seed-barista": "^0.3.1"
+    "lodash.assign": "4.2.0",
+    "seed-barista": "0.3.2"
   }
 }

--- a/test/_genki.js
+++ b/test/_genki.js
@@ -1,4 +1,5 @@
 /* globals describe: true, it: true */
+/* jshint expr: true */
 'use strict';
 
 var expect = require('chai').expect;

--- a/test/genki.addStyle.js
+++ b/test/genki.addStyle.js
@@ -1,4 +1,5 @@
 /* globals describe: true, it: true */
+/* jshint expr: true */
 'use strict';
 
 var expect = require('chai').expect;

--- a/test/genki.css.js
+++ b/test/genki.css.js
@@ -1,4 +1,5 @@
 /* globals describe: true, it: true */
+/* jshint expr: true */
 'use strict';
 
 var expect = require('chai').expect;
@@ -30,8 +31,18 @@ describe('genki.css', function() {
     expect($box.css('position')).to.equal('fixed');
   });
 
-  it('should be able to access Barista data', function() {
+  it('should not have CSSOM by default', function() {
     var world = genki.start({
+      file: 'test/css/batsu.scss',
+    });
+
+    expect(world.styles[0].data).to.be.false;
+    expect(world.styles[0].$('.tanaka')).to.be.false;
+  });
+
+  it('should be able to access Barista data if enableCSSOM: true', function() {
+    var world = genki.start({
+      enableCSSOM: true,
       file: 'test/css/batsu.scss',
     });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1138,9 +1138,9 @@ sax@^1.2.1:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.2.tgz#fd8631a23bc7826bef5d871bdb87378c95647828"
 
-seed-barista@^0.3.1:
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/seed-barista/-/seed-barista-0.3.1.tgz#4a319b68a4cc26348fd18ab6a91e2dd8efe49cdd"
+seed-barista@0.3.2:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/seed-barista/-/seed-barista-0.3.2.tgz#4315971154f0a879b6536909abfea6f38aaaa30a"
   dependencies:
     find-root "1.0.0"
     lodash.assign "4.2.0"


### PR DESCRIPTION
## Updates

* Update to [seed-barista#v0.3.2](https://github.com/helpscout/seed-barista/releases/tag/v0.3.2) for enableCSSOM options
* Disable enableCSSOM by default
* Add jshint as a dev-dependency
* Add linting as part of the test process
* Update tests

Resolves: https://github.com/ItsJonQ/genki/issues/6